### PR TITLE
Update Tycho to 0.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
   <properties>
     <robovm.version>${project.version}</robovm.version>
-    <tycho.version>0.16.0</tycho.version>
-    <tycho-extras.version>0.16.0</tycho-extras.version>
+    <tycho.version>0.20.0</tycho.version>
+    <tycho-extras.version>0.20.0</tycho-extras.version>
     <eclipse-site>http://download.eclipse.org/releases/indigo</eclipse-site>
   </properties>
 


### PR DESCRIPTION
I've been trying to compile the Eclipse plugin via Maven 3.2.1, but it appears that Tycho 0.16 can not deal with that version. The latest Tycho release (0.20) seems to be compatible. I tested this PR with Eclipse Kepler.
