### PR TITLE
Changed the way users can pick simulators

### DIFF
--- a/ui/src/org/robovm/eclipse/internal/IOSSimulatorLaunchConfigurationDelegate.java
+++ b/ui/src/org/robovm/eclipse/internal/IOSSimulatorLaunchConfigurationDelegate.java
@@ -25,8 +25,9 @@ import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.Config.TargetType;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.LaunchParameters;
+import org.robovm.compiler.target.ios.DeviceType;
 import org.robovm.compiler.target.ios.IOSSimulatorLaunchParameters;
-import org.robovm.compiler.target.ios.IOSSimulatorLaunchParameters.Family;
+import org.robovm.compiler.target.ios.SDK;
 import org.robovm.eclipse.RoboVMPlugin;
 
 /**
@@ -37,8 +38,7 @@ public class IOSSimulatorLaunchConfigurationDelegate extends AbstractLaunchConfi
 
     public static final String TYPE_ID = "org.robovm.eclipse.IOSSimulatorLaunchConfigurationType";
     public static final String TYPE_NAME = "iOS Simulator App";
-    public static final String ATTR_IOS_SIM_FAMILY = RoboVMPlugin.PLUGIN_ID + ".IOS_SIM_FAMILY";
-    public static final String ATTR_IOS_SIM_SDK = RoboVMPlugin.PLUGIN_ID + ".IOS_SIM_SDK";
+    public static final String ATTR_IOS_SIM_DEVICE_TYPE = RoboVMPlugin.PLUGIN_ID + ".IOS_SIM_DEVICE_TYPE";
 
     @Override
     protected Arch getArch(ILaunchConfiguration configuration, String mode) {
@@ -49,30 +49,23 @@ public class IOSSimulatorLaunchConfigurationDelegate extends AbstractLaunchConfi
     protected OS getOS(ILaunchConfiguration configuration, String mode) {
         return OS.ios;
     }
-    
+
     @Override
     protected Config configure(Config.Builder configBuilder,
             ILaunchConfiguration configuration, String mode) throws IOException {
-        
         configBuilder.targetType(TargetType.ios);
-        
         return configBuilder.build();
     }
-    
+
     @Override
     protected void customizeLaunchParameters(LaunchParameters launchParameters,
             ILaunchConfiguration configuration, String mode) throws IOException, CoreException {
-
         super.customizeLaunchParameters(launchParameters, configuration, mode);
-        
+
         IOSSimulatorLaunchParameters lp = (IOSSimulatorLaunchParameters) launchParameters;
-        String family = configuration.getAttribute(ATTR_IOS_SIM_FAMILY, (String) null);
-        if (family != null) {
-            lp.setFamily(Family.valueOf(family));
-        }
-        String sdk = configuration.getAttribute(ATTR_IOS_SIM_SDK, "latest");
-        if (!"latest".equals(sdk)) {
-            lp.setSdk(sdk);
+        String deviceTypeId = configuration.getAttribute(ATTR_IOS_SIM_DEVICE_TYPE, (String) null);
+        if (deviceTypeId != null) {
+            lp.setDeviceType(DeviceType.getDeviceType(RoboVMPlugin.getRoboVMHome(), deviceTypeId));
         }
     }
 }

--- a/ui/src/org/robovm/eclipse/internal/IPadSimulatorLaunchShortcut.java
+++ b/ui/src/org/robovm/eclipse/internal/IPadSimulatorLaunchShortcut.java
@@ -16,17 +16,15 @@
  */
 package org.robovm.eclipse.internal;
 
-import org.robovm.compiler.target.ios.IOSSimulatorLaunchParameters.Family;
+import org.robovm.compiler.target.ios.DeviceType.DeviceFamily;
 
 /**
  * @author niklas
  *
  */
 public class IPadSimulatorLaunchShortcut extends IOSSimulatorLaunchShortcut {
-
     @Override
-    protected Family getFamily() {
-        return Family.iPadRetina;
+    protected DeviceFamily getFamily() {
+        return DeviceFamily.iPad;
     }
-    
 }

--- a/ui/src/org/robovm/eclipse/internal/IPhoneSimulatorLaunchShortcut.java
+++ b/ui/src/org/robovm/eclipse/internal/IPhoneSimulatorLaunchShortcut.java
@@ -16,17 +16,15 @@
  */
 package org.robovm.eclipse.internal;
 
-import org.robovm.compiler.target.ios.IOSSimulatorLaunchParameters.Family;
+import org.robovm.compiler.target.ios.DeviceType.DeviceFamily;
 
 /**
  * @author niklas
  *
  */
 public class IPhoneSimulatorLaunchShortcut extends IOSSimulatorLaunchShortcut {
-
     @Override
-    protected Family getFamily() {
-        return Family.iPhoneRetina4Inch;
+    protected DeviceFamily getFamily() {
+        return DeviceFamily.iPhone;
     }
-    
 }


### PR DESCRIPTION
In lock step with https://github.com/robovm/robovm/pull/510 i changed the way users can specify the device type when launching a simulator. The shortcuts for launching an iPhone or iPad simulator are still in tact and will select the first device with the highest SDK version.

The launch configuration allows the user to select a specific device type id (device type + sdk version) from a drop down box, replacing the old behaviour of selecting a family and SDK.

![New Launch Dialog](http://libgdx.badlogicgames.com/uploads/Screen%20Shot%202014-09-23%20at%2021.39.13-tzbiUPn5HN.png)

On a related note: users can not select which SDK they want to build against (unless specified in robovm.xml). The SDK setting in the old dialog only seems to have been passed to ios-sim, but not to the compilation stage. We should probably extend the RoboVM project settings dialog to let users specify which SDK they want to build against. That dialog currently only sports settings for incremental compilation.
